### PR TITLE
feat: support non-avro messages

### DIFF
--- a/aet/kafka.py
+++ b/aet/kafka.py
@@ -25,6 +25,7 @@ import json
 from kafka import KafkaConsumer as VanillaConsumer
 from spavro.datafile import DataFileReader
 from spavro.io import DatumReader
+from spavro.schema import AvroException
 
 from jsonpath_ng import parse
 
@@ -139,47 +140,84 @@ class KafkaConsumer(VanillaConsumer):
                 partition_result = []
                 # a package can contain multiple messages serialzed with the same schema
                 for package in packages:
-                    package_result = {
-                        "schema": None,
-                        "messages": []
-                    }
-                    schema = None
                     obj = io.BytesIO()
                     obj.write(package.value)
-                    reader = DataFileReader(obj, DatumReader())
-
-                    # We can get the schema directly from the reader.
-                    # we get a mess of unicode that can't be json parsed so we need ast
-                    raw_schema = ast.literal_eval(str(reader.meta))
-                    schema = json.loads(raw_schema.get("avro.schema"))
-                    if not schema:
-                        last_schema = None
-                        mask = None
-
-                        def approval_filter(x):
-                            return True
-                    elif schema != last_schema:
-                        last_schema = schema
-                        package_result["schema"] = schema
-                        # prepare mask and filter
-                        approval_filter = self.get_approval_filter()
-                        mask = self.get_mask_from_schema(schema)
-                    else:
-                        package_result["schema"] = last_schema
-                    for x, msg in enumerate(reader):
-                        # is message is ready for consumption, process it
-                        if approval_filter(msg):
-                            # apply masking
-                            processed_message = self.mask_message(msg, mask)
-                            package_result["messages"].append(processed_message)
-
-                    obj.close()  # don't forget to close your open IO object.
-                    if package_result.get("schema") or len(package_result["messages"]) > 0:
-                        partition_result.append(package_result)
+                    try:
+                        reader = DataFileReader(obj, DatumReader())
+                        (
+                            package_result,
+                            last_schema,
+                            mask,
+                            approval_filter
+                        ) = \
+                            self._reader_to_messages(
+                                reader,
+                                last_schema,
+                                mask,
+                                approval_filter
+                        )
+                        obj.close()  # don't forget to close your open IO object.
+                        if package_result.get("schema") or len(package_result["messages"]) > 0:
+                            partition_result.append(package_result)
+                    except AvroException:
+                        reader = None
+                        (
+                            package_result,
+                            last_schema,
+                            mask,
+                            approval_filter
+                        ) = (
+                            self._unpack_json_message(obj),
+                            None,
+                            None,
+                            None
+                        )
+                        obj.close()  # don't forget to close your open IO object.
+                        if len(package_result["messages"]) > 0:
+                            partition_result.append(package_result)
                 if len(partition_result) > 0:
                     name = "topic:%s-partition:%s" % (part.topic, part.partition)
                     result[name] = partition_result
         return result
+
+    def _reader_to_messages(self, reader, last_schema, mask, approval_filter):
+        package_result = {
+            "schema": None,
+            "messages": []
+        }
+        # We can get the schema directly from the reader.
+        # we get a mess of unicode that can't be json parsed so we need ast
+        raw_schema = ast.literal_eval(str(reader.meta))
+        schema = json.loads(raw_schema.get("avro.schema"))
+        if not schema:
+            last_schema = None
+            mask = None
+
+            def approval_filter(x):
+                return True
+        elif schema != last_schema:
+            last_schema = schema
+            package_result["schema"] = schema
+            # prepare mask and filter
+            approval_filter = self.get_approval_filter()
+            mask = self.get_mask_from_schema(schema)
+        else:
+            package_result["schema"] = last_schema
+        for x, msg in enumerate(reader):
+            # is message is ready for consumption, process it
+            if approval_filter(msg):
+                # apply masking
+                processed_message = self.mask_message(msg, mask)
+                package_result["messages"].append(processed_message)
+
+        return package_result, last_schema, mask, approval_filter
+
+    def _unpack_json_message(self, reader):
+        package_result = {
+            "schema": None,
+            "messages": [json.loads(reader.getvalue().decode('utf-8'))]
+        }
+        return package_result
 
     def seek_to_beginning(self):
         # We override this method to allow for seeking before any messages have been consumed

--- a/aet/kafka.py
+++ b/aet/kafka.py
@@ -129,10 +129,6 @@ class KafkaConsumer(VanillaConsumer):
         last_schema = None
         mask = None
         approval_filter = None
-        '''
-        def approval_filter(x):
-            return True
-        '''
         partitioned_messages = self.poll(timeout_ms, max_records)
         if partitioned_messages:
             for part, packages in partitioned_messages.items():
@@ -189,12 +185,6 @@ class KafkaConsumer(VanillaConsumer):
         # we get a mess of unicode that can't be json parsed so we need ast
         raw_schema = ast.literal_eval(str(reader.meta))
         schema = json.loads(raw_schema.get("avro.schema"))
-        # if not schema:
-        #     return self._unpack_bytes_message(file_obj), None, None, None
-        # last_schema = None
-        # mask = None
-        # def approval_filter(x):
-        #     return True
         if schema != last_schema:
             last_schema = schema
             package_result["schema"] = schema

--- a/conf/pip/primary-requirements.txt
+++ b/conf/pip/primary-requirements.txt
@@ -16,6 +16,7 @@ kafka-python
 mock
 pytest
 pytest-cov
+pytest-lazy-fixture
 pytest-runner
 redis
 requests

--- a/conf/pip/requirements.txt
+++ b/conf/pip/requirements.txt
@@ -37,6 +37,7 @@ pycodestyle==2.5.0
 pyflakes==2.1.0
 pytest==4.3.0
 pytest-cov==2.6.1
+pytest-lazy-fixture==0.5.1
 pytest-runner==4.4
 redis==3.2.0
 requests==2.21.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -231,16 +231,6 @@ def messages_test_text_ascii(topic_writer):
     return messages
 
 
-# @pytest.mark.integration
-# @pytest.fixture(scope="session")
-# def messages_test_avro_no_schema(topic_writer):
-#     topic = "TestAvroNoSchema"
-#     src = "TestBooleanPass"
-#     messages = topic_writer(
-#         topic=topic, source=src, encoding='avro', is_json=True, include_schema=False)
-#     return messages
-
-
 @pytest.mark.integration
 @pytest.fixture(scope="session")
 def messages_test_boolean_pass(topic_writer):

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -37,6 +37,35 @@ from aet.kafka import KafkaConsumer
 # Integration Tests #
 #####################
 
+@pytest.mark.integration
+def test_read_messages_no_schema(messages_test_no_schema, default_consumer_args):
+    _ids = [m['id'] for m in messages_test_no_schema]
+    topic = "TestPlainMessages"
+    assert(len(messages_test_no_schema) ==
+           topic_size), "Should have generated the right number of messages"
+    iter_consumer = KafkaConsumer(**default_consumer_args)
+    iter_consumer.subscribe(topic)
+    iter_consumer.seek_to_beginning()
+    # more than a few hundres is too large to grab in one pass when not serialized
+    for x in range(int(3 * topic_size / 500)):
+        messages = iter_consumer.poll_and_deserialize(timeout_ms=10000, max_records=1000)
+        # read messages and check masking
+        for partition, packages in messages.items():
+            for package in packages:
+                for msg in package.get("messages"):
+                    _id = msg.get('id')
+                    try:
+                        # remove found records from our pick list
+                        _ids.remove(_id)
+                    except ValueError:
+                        # record may be in another batch
+                        pass
+        if len(_ids) == 0:
+            break
+    iter_consumer.close()
+    # make sure we read all the records
+    assert(len(_ids) == 0)
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize("emit_level,unmasked_fields", [


### PR DESCRIPTION
Previously message values needed to be serialized avro. This patch lets values be utf-8 or ascii strings or json structures. The consumer library figures out which type of encoding to apply in order of preference:
- avro
- utf-8 json
- utf-8 string
- ascii json
- ascii string