### PR TITLE
feat: mask config items

### DIFF
--- a/aet/job.py
+++ b/aet/job.py
@@ -83,6 +83,7 @@ class BaseJob(AbstractResource):
         'resume',
         'get_status'
     ]
+    _masked_fields: List[str] = []  # jsonpaths to be masked when showing definition
 
     @property
     @abstractmethod  # required

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -79,6 +79,7 @@ class TestResource(BaseResource):
 
     name = 'resource'
     jobs_path = '$.no.real.job'
+    _masked_fields = ['password']
 
     public_actions = BASE_PUBLIC_ACTIONS + [
         'upper',


### PR DESCRIPTION
Since consumers are typically exposed to the whole tenant, we want to allow people to add credentials to a resource, and for the consumer to use it, but not let it be read back again. The solution was to add a class property that's used to mask sensitive fields in configurations when they're read out of Redis.