### PR TITLE
feat: added timeout monitoring of threads triggered by healthcheck

### DIFF
--- a/aet/api.py
+++ b/aet/api.py
@@ -225,7 +225,14 @@ class APIServer(object):
 
     def request_healthcheck(self) -> Response:
         with self.app.app_context():
-            return Response({"healthy": True})
+            try:
+                expired = self.consumer.healthcheck()
+                if not expired:
+                    return Response({"healthy": True})
+                else:
+                    return Response(expired, 500)
+            except Exception as err:
+                return Response(f"Unexpected error: {err}", 500)
 
     # Generic CRUD
 

--- a/aet/settings.py
+++ b/aet/settings.py
@@ -25,6 +25,9 @@ import os
 class Settings(dict):
     # A container for our settings
     def __init__(self, file_path=None, alias=None, exclude=None):
+        # takes precident over env and initial values. Case sensitive
+        # useful for tests
+        self.overrides = {}
         if not exclude:
             self.exclude = []
         else:
@@ -39,13 +42,20 @@ class Settings(dict):
         except KeyError:
             return default
 
+    def override(self, key, value):
+        self.overrides[key] = value
+
     def __getattr__(self, name):
         try:
+            if name in self.overrides:
+                return self.overrides[name]
             super().__getattr__(name)
         except AttributeError:
             return self.get(name)
 
     def __getitem__(self, key):
+        if key in self.overrides:
+            return self.overrides[key]
         if self.alias and key in self.alias:
             key = self.alias.get(key)
         result = os.environ.get(key.upper())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # ---------------------------------
 
   zookeeper-test:
-    image: confluentinc/cp-zookeeper:5.2.1
+    image: confluentinc/cp-zookeeper:5.5.1
     environment:
       ZOOKEEPER_CLIENT_PORT: 32181
       ZOOKEEPER_TICK_TIME: 2000
@@ -15,7 +15,7 @@ services:
       - moby:127.0.0.1
 
   kafka-test:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.5.1
     links:
       - zookeeper-test
     environment:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ python_files = tests/test*.py
 addopts = --maxfail=100 -p no:warnings
  # For super verbose tests...
 # log_cli = 1
-# log_cli_level = ERROR
+# log_cli_level = DEBUG
 # log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 # log_cli_date_format=%Y-%m-%d %H:%M:%S
 


### PR DESCRIPTION
As long running, multi-thread processes sometimes things happen days or weeks into deployment that are mysterious. Usually this means a thread hanging without exception. This patch adds a self reporting mechanism for each job thread in the _run method. Calls to `/healthcheck` which should be made by the supporting framework will check the last checkin from each thread against a max_idle value. If all known jobs are under the threshold, the hc returns 200. If any fail, it returns a 500. In addition you have the option to dump a stacktrace for all running threads to the log on a healthcheck failure like this. Since it's likely that there will be a couple failed hcs before the framework kills the consumer, you should have an opportunity to see over a few minutes which threads are stuck and what they were doing that got them into that state.

Added new env options:
 - MAX_JOB_IDLE_SEC (600)
 - DUMP_STACK_ON_EXPIRE (False)