### PR TITLE
feat: add message handling exception and optional handler

### DIFF
--- a/aet/exceptions.py
+++ b/aet/exceptions.py
@@ -32,3 +32,15 @@ class ConsumerHttpException(Exception):
 
     def as_response(self):
         return Response(self.message, self.status_code)
+
+
+class MessageHandlingException(Exception):
+    '''
+    Generic exception thrown by implementors of BaseJob within their
+    implementation of _get_messages or _handle_messages which will then trigger
+    the _on_message_handle_exception() block
+    '''
+
+    def __init__(self, message: str, details=None, **kwargs):
+        super().__init__(message)
+        self.details = details or {}

--- a/aet/job.py
+++ b/aet/job.py
@@ -29,7 +29,7 @@ from typing import Any, Callable, Dict, List, Union
 
 from aether.python.redis.task import Task, TaskEvent, TaskHelper
 
-from .exceptions import ConsumerHttpException
+from .exceptions import ConsumerHttpException, MessageHandlingException
 from .helpers import classproperty, require_property
 from .jsonpath import CachedParser
 from .logger import get_logger, callback_logger
@@ -187,6 +187,8 @@ class BaseJob(AbstractResource):
                     messages = self._get_messages(config)
                     if messages:
                         self._handle_messages(config, messages)
+                except MessageHandlingException as mhe:
+                    self._on_message_handle_exception(mhe)
                 except RuntimeError as rer:
                     self.log.critical(f'RuntimeError: {self._id} | {rer}')
                     self.safe_sleep(self.sleep_delay)
@@ -215,6 +217,9 @@ class BaseJob(AbstractResource):
         sleep(self.sleep_delay)
         LOG.debug('Handling Messages')
         self.value += 1
+
+    def _on_message_handle_exception(self, mhe: MessageHandlingException):
+        pass
 
     def _cause_exception(self, exception: Exception = ValueError) -> None:
         # intentionally cause the thread to crash for testing purposes

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -785,6 +785,16 @@ def test_itest_add_ten_jobs(IJobManager):
 
 
 @pytest.mark.unit
+def test_itest_throw_catchable_error(IJobManager):
+    for job in IJobManager.jobs.values():
+        assert(job.exceptions == 0)
+        job.throw_catchable()
+    sleep(20)
+    for job in IJobManager.jobs.values():
+        assert(job.exceptions == 1), job.exceptions
+
+
+@pytest.mark.unit
 def test_itest_modify_resources(IJobManager):
     new_value = 2
     for res in i_resources:


### PR DESCRIPTION
This enables consumers to more easily throw an exception on a known but problematic state, and then catch and handle it outside of the get_message handle_message functions.
For example, if you were to get_messages and then find that you temporarily cannot handle them, this allows you to rollback the KafkaConsumer offset so that they're not lost.