### PR TITLE
feat: add /check-consumer endpoint

### DIFF
--- a/aet/api.py
+++ b/aet/api.py
@@ -26,7 +26,7 @@ from webtest.http import StopableWSGIServer
 
 from .exceptions import ConsumerHttpException
 from .logger import get_logger
-from .settings import CONSUMER_CONFIG
+from .settings import CONSUMER_CONFIG, VERSION, REVISION
 
 LOG = get_logger('API')
 
@@ -171,6 +171,7 @@ class APIServer(object):
             methods=['GET', 'POST'])
 
         self.register('health', self.request_healthcheck)
+        self.register('check-consumer', self.request_consumer_info)
 
     def register(self, route_name, fn, **options) -> None:
         self.app.add_url_rule('/%s' % route_name, route_name, view_func=fn, **options)
@@ -231,6 +232,14 @@ class APIServer(object):
                     return Response(expired, 500)
             except Exception as err:
                 return Response(f'Unexpected error: {err}', 500)
+
+    def request_consumer_info(self) -> Response:
+        with self.app.app_context():
+            return Response({
+                'consumer_name': self.settings.get('CONSUMER_NAME'),
+                'consumer_version': VERSION,
+                'consumer_revision': REVISION,
+            })
 
     # Generic CRUD
 

--- a/aet/settings.py
+++ b/aet/settings.py
@@ -93,3 +93,20 @@ KAFKA_CONFIG: Settings = Settings(file_path=os.environ.get('KAFKA_CONFIG_PATH', 
 
 check_required_fields(CONSUMER_CONFIG, os.environ.get('REQUIRED_CONSUMER_CONFIG', '[]'))
 check_required_fields(KAFKA_CONFIG, os.environ.get('REQUIRED_KAFKA_CONFIG', '[]'))
+
+
+# ------------------------------------------------------------------------------
+# Version and revision
+# ------------------------------------------------------------------------------
+try:
+    with open('/var/tmp/VERSION') as fp:
+        VERSION = fp.read().strip()
+except Exception:
+    VERSION = '#.#.#'
+
+try:
+    with open('/var/tmp/REVISION') as fp:
+        REVISION = fp.read().strip()
+except Exception:
+    REVISION = '---'
+# ------------------------------------------------------------------------------

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -481,7 +481,8 @@ def test_cached_parser__bad_path():
                         ('resource/validate_pretty', -1, False),
                         ('resource/null?id=fake', -1, True),  # properly dispatched to missing JM
                         ('bad_resource/list', {}, True),
-                        ('health', 'healthy', False)
+                        ('health', 'healthy', False),
+                        ('check-consumer', -1, False),
 ])
 def test_api_get_calls(call, result, raises_error, mocked_api):
     user = settings.CONSUMER_CONFIG.get('ADMIN_USER')


### PR DESCRIPTION
This will require a new release and a change in the consumers' setup:

- `Dockerfile`

```Dockerfile
ARG VERSION=0.0.0
ARG REVISION=alpha

RUN mkdir -p /var/tmp && \
    echo $VERSION > /var/tmp/VERSION && \
    echo $REVISION > /var/tmp/REVISION
```

- `scripts/release.sh`
```shell
# Build and release docker image
IMAGE_REPO="ehealthafrica"
APP="my-consumer"
VERSION=$TRAVIS_TAG
TAG="${IMAGE_REPO}/${APP}:${VERSION}"

echo "Building image"
docker build \
    --tag $TAG \
    --build-arg VERSION=$VERSION \
    --build-arg REVISION=$TRAVIS_COMMIT \
    ./consumer
echo "Image built"

echo "Pushing image"
docker push $TAG
echo "Image pushed"
```