### PR TITLE
fix: WSGI -> asyncore_use_poll

### DIFF
--- a/aet/api.py
+++ b/aet/api.py
@@ -86,7 +86,8 @@ class APIServer(object):
         self.http = StopableWSGIServer.create(
             self.app.wsgi_app,
             port=server_port,
-            host=server_ip
+            host=server_ip,
+            asyncore_use_poll=True  # default (False) can hit file descriptor ulimit
         )
         self.app.logger.debug('Http Serve start.')
         self.add_endpoints()


### PR DESCRIPTION
 - fix: tell API WSGI server to use poll internally to avoid file descriptor limit

relates to:
https://github.com/Pylons/waitress/issues/31

And:
```
ValueError: filedescriptor out of range in select()
```
encountered while running.

…